### PR TITLE
Replace cv_fold with fold_number to match sl3

### DIFF
--- a/R/CF_likelihood.R
+++ b/R/CF_likelihood.R
@@ -60,15 +60,15 @@ CF_Likelihood <- R6Class(
       return(cf_tasks)
     },
 
-    get_likelihood = function(tmle_task, node, cv_fold = -1) {
+    get_likelihood = function(tmle_task, node, fold_number = "full") {
       # todo: this will not handle the case where the cf_likelihood is based on
       # an updated likelihood factor (e.g. old tx shift)
       if (node %in% self$intervention_nodes) {
-        likelihood_values <- super$get_likelihood(tmle_task, node, cv_fold)
+        likelihood_values <- super$get_likelihood(tmle_task, node, fold_number)
       } else {
         # dispatch to observed likelihood if not an intervention node
         # that way, we get updates to those nodes
-        likelihood_values <- self$observed_likelihood$get_likelihood(tmle_task, node, cv_fold)
+        likelihood_values <- self$observed_likelihood$get_likelihood(tmle_task, node, fold_number)
       }
 
       return(likelihood_values)

--- a/R/LF_base.R
+++ b/R/LF_base.R
@@ -38,17 +38,17 @@ LF_base <- R6Class(
 
       # subclasses may do more, like fit sl3 models
     },
-    get_density = function(tmle_task, cv_fold) {
+    get_density = function(tmle_task, fold_number) {
       stop("density not supported")
     },
-    get_mean = function(tmle_task, cv_fold) {
+    get_mean = function(tmle_task, fold_number) {
       stop("mean not supported")
     },
-    get_likelihood = function(tmle_task, cv_fold = -1) {
+    get_likelihood = function(tmle_task, fold_number = "full") {
       if (self$type == "mean") {
-        values <- self$get_mean(tmle_task, cv_fold)
+        values <- self$get_mean(tmle_task, fold_number)
       } else {
-        values <- self$get_density(tmle_task, cv_fold)
+        values <- self$get_density(tmle_task, fold_number)
       }
       return(values)
     },

--- a/R/LF_emp.R
+++ b/R/LF_emp.R
@@ -36,10 +36,10 @@ LF_emp <- R6Class(
       super$initialize(name, ..., type = "density")
       private$.name <- name
     },
-    get_mean = function(tmle_task, cv_fold = -1) {
+    get_mean = function(tmle_task, fold_number = "full") {
       stop("nothing to predict")
     },
-    get_density = function(tmle_task, cv_fold = -1) {
+    get_density = function(tmle_task, fold_number = "full") {
       weights <- tmle_task$weights
       return(weights / sum(weights))
     }

--- a/R/LF_fit.R
+++ b/R/LF_fit.R
@@ -62,24 +62,17 @@ LF_fit <- R6Class(
       super$train(tmle_task)
       private$.learner <- learner_fit
     },
-    get_mean = function(tmle_task, cv_fold) {
+    get_mean = function(tmle_task, fold_number) {
       learner_task <- tmle_task$get_regression_task(self$name)
       learner <- self$learner
-      if (cv_fold == -1) {
-        preds <- learner$predict(learner_task)
-      } else {
-        preds <- learner$predict_fold(learner_task, cv_fold)
-      }
+      preds <- learner$predict_fold(learner_task, fold_number)
       return(preds)
     },
-    get_density = function(tmle_task, cv_fold) {
+    get_density = function(tmle_task, fold_number) {
       learner_task <- tmle_task$get_regression_task(self$name)
       learner <- self$learner
-      if (cv_fold == -1) {
-        preds <- learner$predict(learner_task)
-      } else {
-        preds <- learner$predict_fold(learner_task, cv_fold)
-      }
+      preds <- learner$predict_fold(learner_task, fold_number)
+
       outcome_type <- self$learner$training_task$outcome_type
       observed <- outcome_type$format(learner_task$Y)
       if (outcome_type$type == "binomial") {

--- a/R/LF_known.R
+++ b/R/LF_known.R
@@ -46,7 +46,7 @@ LF_known <- R6Class(
       private$.mean_fun <- mean_fun
       private$.density_fun <- density_fun
     },
-    get_mean = function(tmle_task, cv_fold) {
+    get_mean = function(tmle_task, fold_number) {
       learner_task <- tmle_task$get_regression_task(self$name, bound = FALSE)
       preds <- self$mean_fun(learner_task)
 
@@ -60,7 +60,7 @@ LF_known <- R6Class(
       }
       return(preds)
     },
-    get_density = function(tmle_task, cv_fold) {
+    get_density = function(tmle_task, fold_number) {
       learner_task <- tmle_task$get_regression_task(self$name, bound = FALSE)
       preds <- self$density_fun(learner_task)
 

--- a/R/LF_static.R
+++ b/R/LF_static.R
@@ -45,10 +45,10 @@ LF_static <- R6Class(
       private$.value <- value
       private$.variable_type <- variable_type("constant", value)
     },
-    get_mean = function(tmle_task, cv_fold) {
+    get_mean = function(tmle_task, fold_number) {
       return(rep(self$value, tmle_task$nrow))
     },
-    get_density = function(tmle_task, cv_fold) {
+    get_density = function(tmle_task, fold_number) {
       observed <- tmle_task$get_tmle_node(self$name)
       likelihood <- as.numeric(self$value == observed)
 

--- a/R/Likelihood.R
+++ b/R/Likelihood.R
@@ -60,33 +60,33 @@ Likelihood <- R6Class(
         stop("factor_list and task$npsem must have matching names")
       }
     },
-    get_likelihood = function(tmle_task, node, cv_fold = -1) {
+    get_likelihood = function(tmle_task, node, fold_number = "full") {
       likelihood_factor <- self$factor_list[[node]]
       # first check for cached values for this task
-      likelihood_values <- self$cache$get_values(likelihood_factor, tmle_task, cv_fold)
+      likelihood_values <- self$cache$get_values(likelihood_factor, tmle_task, fold_number)
 
       if (is.null(likelihood_values)) {
         # if not, generate new ones
-        likelihood_values <- likelihood_factor$get_likelihood(tmle_task, cv_fold)
-        self$cache$set_values(likelihood_factor, tmle_task, 0, cv_fold, likelihood_values)
+        likelihood_values <- likelihood_factor$get_likelihood(tmle_task, fold_number)
+        self$cache$set_values(likelihood_factor, tmle_task, 0, fold_number, likelihood_values)
       }
 
       return(likelihood_values)
     },
-    get_likelihoods = function(tmle_task, nodes = NULL, cv_fold = -1) {
+    get_likelihoods = function(tmle_task, nodes = NULL, fold_number = "full") {
       if (is.null(nodes)) {
         nodes <- self$nodes
       }
 
       if (length(nodes) > 1) {
         all_likelihoods <- lapply(nodes, function(node) {
-          self$get_likelihood(tmle_task, node, cv_fold)
+          self$get_likelihood(tmle_task, node, fold_number)
         })
         likelihood_dt <- as.data.table(all_likelihoods)
         setnames(likelihood_dt, nodes)
         return(likelihood_dt)
       } else {
-        return(self$get_likelihood(tmle_task, nodes[[1]], cv_fold))
+        return(self$get_likelihood(tmle_task, nodes[[1]], fold_number))
       }
     },
     get_possible_counterfactuals = function(nodes = NULL) {

--- a/R/Likelihood_cache.R
+++ b/R/Likelihood_cache.R
@@ -17,18 +17,18 @@ Likelihood_cache <- R6Class(
     tasks_at_step = function(current_step) {
       self$tasks[task_uuids]
     },
-    get_update_step = function(likelihood_factor, tmle_task, cv_fold) {
-      key <- self$key(likelihood_factor, tmle_task, cv_fold)
+    get_update_step = function(likelihood_factor, tmle_task, fold_number) {
+      key <- self$key(likelihood_factor, tmle_task, fold_number)
       step_key <- sprintf("%s_%s", key, "step")
       get0(step_key, self$cache, inherits = FALSE)
     },
-    key = function(likelihood_factor, tmle_task, cv_fold) {
-      key <- sprintf("%s_%s_%s", likelihood_factor$uuid, tmle_task$uuid, cv_fold)
+    key = function(likelihood_factor, tmle_task, fold_number) {
+      key <- sprintf("%s_%s_%s", likelihood_factor$uuid, tmle_task$uuid, fold_number)
       return(key)
     },
-    set_values = function(likelihood_factor, tmle_task, update_step = 0, cv_fold, values) {
+    set_values = function(likelihood_factor, tmle_task, update_step = 0, fold_number, values) {
       self$cache_task(tmle_task)
-      key <- self$key(likelihood_factor, tmle_task, cv_fold)
+      key <- self$key(likelihood_factor, tmle_task, fold_number)
       assign(key, values, self$cache)
 
       step_key <- sprintf("%s_%s", key, "step")
@@ -36,9 +36,9 @@ Likelihood_cache <- R6Class(
 
       return(1)
     },
-    get_values = function(likelihood_factor, tmle_task, cv_fold) {
-      # matching_index <- self$find_match(likelihood_factor, tmle_task, cv_fold)
-      key <- self$key(likelihood_factor, tmle_task, cv_fold)
+    get_values = function(likelihood_factor, tmle_task, fold_number) {
+      # matching_index <- self$find_match(likelihood_factor, tmle_task, fold_number)
+      key <- self$key(likelihood_factor, tmle_task, fold_number)
       values <- get0(key, self$cache, inherits = FALSE)
 
       return(values)

--- a/R/Param_ATE.R
+++ b/R/Param_ATE.R
@@ -51,22 +51,22 @@ Param_ATE <- R6Class(
       private$.cf_likelihood_treatment <- CF_Likelihood$new(observed_likelihood, intervention_list_treatment)
       private$.cf_likelihood_control <- CF_Likelihood$new(observed_likelihood, intervention_list_control)
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
 
       intervention_nodes <- union(names(self$intervention_list_treatment), names(self$intervention_list_control))
 
-      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
+      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, fold_number)
 
       HA <- (cf_pA_treatment - cf_pA_control) / pA
 
       return(list(Y = HA))
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
+    estimates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
@@ -74,13 +74,13 @@ Param_ATE <- R6Class(
       intervention_nodes <- union(names(self$intervention_list_treatment), names(self$intervention_list_control))
       
       # clever_covariates happen here (for this param) only, but this is repeated computation
-      HA <- self$clever_covariates(tmle_task, cv_fold)[[self$outcome_node]]
+      HA <- self$clever_covariates(tmle_task, fold_number)[[self$outcome_node]]
 
 
       # todo: make sure we support updating these params
-      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
+      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, fold_number)
 
       # todo: extend for stochastic
       cf_task_treatment <- self$cf_likelihood_treatment$cf_tasks[[1]]
@@ -88,9 +88,9 @@ Param_ATE <- R6Class(
 
       Y <- tmle_task$get_tmle_node(self$outcome_node)
 
-      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, cv_fold)
-      EY1 <- self$observed_likelihood$get_likelihood(cf_task_treatment, self$outcome_node, cv_fold)
-      EY0 <- self$observed_likelihood$get_likelihood(cf_task_control, self$outcome_node, cv_fold)
+      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, fold_number)
+      EY1 <- self$observed_likelihood$get_likelihood(cf_task_treatment, self$outcome_node, fold_number)
+      EY0 <- self$observed_likelihood$get_likelihood(cf_task_control, self$outcome_node, fold_number)
 
       psi <- mean(EY1 - EY0)
 

--- a/R/Param_ATT.R
+++ b/R/Param_ATT.R
@@ -59,7 +59,7 @@ Param_ATT <- R6Class(
       private$.cf_likelihood_treatment <- CF_Likelihood$new(observed_likelihood, intervention_list_treatment)
       private$.cf_likelihood_control <- CF_Likelihood$new(observed_likelihood, intervention_list_control)
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
@@ -68,9 +68,9 @@ Param_ATT <- R6Class(
       intervention_nodes <- names(self$intervention_list_treatment)
 
       # todo: make sure we support updating these params
-      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
+      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, fold_number)
 
       # todo: rethink that last term
       HA <- cf_pA_treatment - cf_pA_control * ((1 - pA) / pA)
@@ -81,15 +81,15 @@ Param_ATT <- R6Class(
       cf_task_treatment <- self$cf_likelihood_treatment$cf_tasks[[1]]
       cf_task_control <- self$cf_likelihood_control$cf_tasks[[1]]
 
-      EY1 <- self$observed_likelihood$get_likelihoods(cf_task_treatment, self$outcome_node, cv_fold)
-      EY0 <- self$observed_likelihood$get_likelihoods(cf_task_control, self$outcome_node, cv_fold)
+      EY1 <- self$observed_likelihood$get_likelihoods(cf_task_treatment, self$outcome_node, fold_number)
+      EY0 <- self$observed_likelihood$get_likelihoods(cf_task_control, self$outcome_node, fold_number)
 
       psi <- mean((EY1 - EY0) * (pA / pA_overall))
       CY <- (EY1 - EY0) - psi
 
       return(list(Y = HA, A = CY))
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
+    estimates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
@@ -98,9 +98,9 @@ Param_ATT <- R6Class(
       intervention_nodes <- names(self$intervention_list_treatment)
 
       # todo: make sure we support updating these params
-      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
+      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_treatment <- self$cf_likelihood_treatment$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA_control <- self$cf_likelihood_control$get_likelihoods(tmle_task, intervention_nodes, fold_number)
 
       # todo: rethink that last term
       HA <- cf_pA_treatment - cf_pA_control * ((1 - pA) / pA)
@@ -116,9 +116,9 @@ Param_ATT <- R6Class(
       # todo: fix hardcoding
       A <- tmle_task$get_tmle_node("A")
 
-      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, cv_fold)
-      EY1 <- self$observed_likelihood$get_likelihood(cf_task_treatment, self$outcome_node, cv_fold)
-      EY0 <- self$observed_likelihood$get_likelihood(cf_task_control, self$outcome_node, cv_fold)
+      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, fold_number)
+      EY1 <- self$observed_likelihood$get_likelihood(cf_task_treatment, self$outcome_node, fold_number)
+      EY0 <- self$observed_likelihood$get_likelihood(cf_task_control, self$outcome_node, fold_number)
 
       psi <- mean((EY1 - EY0) * (pA / pA_overall))
       CY <- (EY1 - EY0) - psi

--- a/R/Param_TSM.R
+++ b/R/Param_TSM.R
@@ -52,13 +52,13 @@ Param_TSM <- R6Class(
       super$initialize(observed_likelihood, ..., outcome_node = outcome_node)
       private$.cf_likelihood <- make_CF_Likelihood(observed_likelihood, intervention_list)
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
       intervention_nodes <- names(self$intervention_list)
-      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
-      cf_pA <- self$cf_likelihood$get_likelihoods(tmle_task, intervention_nodes, cv_fold)
+      pA <- self$observed_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
+      cf_pA <- self$cf_likelihood$get_likelihoods(tmle_task, intervention_nodes, fold_number)
 
       HA <- cf_pA / pA
 
@@ -68,7 +68,7 @@ Param_TSM <- R6Class(
       }
       return(list(Y = unlist(HA, use.names = FALSE)))
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
+    estimates = function(tmle_task = NULL, fold_number = "full") {
       if (is.null(tmle_task)) {
         tmle_task <- self$observed_likelihood$training_task
       }
@@ -81,13 +81,13 @@ Param_TSM <- R6Class(
 
 
       # clever_covariates happen here (for this param) only, but this is repeated computation
-      HA <- self$clever_covariates(tmle_task, cv_fold)[[self$outcome_node]]
+      HA <- self$clever_covariates(tmle_task, fold_number)[[self$outcome_node]]
 
       # clever_covariates happen here (for all fit params), and this is repeated computation
-      EYA <- unlist(self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, cv_fold), use.names = FALSE)
+      EYA <- unlist(self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, fold_number), use.names = FALSE)
 
       # clever_covariates happen here (for all fit params), and this is repeated computation
-      EY1 <- unlist(self$cf_likelihood$get_likelihood(cf_task, self$outcome_node, cv_fold), use.names = FALSE)
+      EY1 <- unlist(self$cf_likelihood$get_likelihood(cf_task, self$outcome_node, fold_number), use.names = FALSE)
 
       # todo: integrate unbounding logic into likelihood class, or at least put it in a function
       variable_type <- tmle_task$npsem[[self$outcome_node]]$variable_type

--- a/R/Param_base.R
+++ b/R/Param_base.R
@@ -24,10 +24,10 @@ Param_base <- R6Class(
       private$.observed_likelihood <- observed_likelihood
       private$.outcome_node <- outcome_node
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       stop("Param_base is a base class")
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
+    estimates = function(tmle_task = NULL, fold_number = "full") {
       stop("Param_base is a base class")
     }
   ),

--- a/R/Param_delta.R
+++ b/R/Param_delta.R
@@ -23,14 +23,14 @@ Param_delta <- R6Class(
       private$.delta_param <- delta_param
       private$.parent_parameters <- parent_parameters
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       return(list())
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
+    estimates = function(tmle_task = NULL, fold_number = "full") {
       estimates <- lapply(
         self$parent_parameters,
         function(tmle_param) {
-          tmle_param$estimates(tmle_task, cv_fold)
+          tmle_param$estimates(tmle_task, fold_number)
         }
       )
 

--- a/R/Param_mean.R
+++ b/R/Param_mean.R
@@ -43,11 +43,11 @@ Param_mean <- R6Class(
     initialize = function(observed_likelihood, ..., outcome_node = "Y") {
       super$initialize(observed_likelihood, ..., outcome_node = outcome_node)
     },
-    clever_covariates = function(tmle_task = NULL, cv_fold = -1) {
+    clever_covariates = function(tmle_task = NULL, fold_number = "full") {
       return(list(Y = rep(1, tmle_task$nrow)))
     },
-    estimates = function(tmle_task = NULL, cv_fold = -1) {
-      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, cv_fold)
+    estimates = function(tmle_task = NULL, fold_number = "full") {
+      EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, fold_number)
 
       # todo: integrate unbounding logic into likelihood class, or at least put it in a function
       variable_type <- tmle_task$npsem[[self$outcome_node]]$variable_type

--- a/R/tmle3_Fit.R
+++ b/R/tmle3_Fit.R
@@ -128,7 +128,7 @@ tmle3_Fit <- R6Class(
       self$updater$update(self$likelihood, self$tmle_task)
       private$.steps <- self$updater$steps
 
-      # todo: final estimates are always on cv_fold=-1 (refit/full fit), verify that this is what we want
+      # todo: final estimates are always on fold_number="full" (refit/full fit), verify that this is what we want
       estimates <- lapply(
         self$tmle_params,
         function(tmle_param) {

--- a/tests/testthat/test-ATE.R
+++ b/tests/testthat/test-ATE.R
@@ -70,7 +70,7 @@ tmle3_psi <- tmle_fit$summary$tmle_est
 tmle3_se <- tmle_fit$summary$se
 tmle3_epsilon <- updater$epsilons[[1]]$Y
 
-submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, -1)
+submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, "full")
 #################################################
 # compare with the tmle package
 library(tmle)

--- a/tests/testthat/test-basic_intevention.R
+++ b/tests/testthat/test-basic_intevention.R
@@ -61,7 +61,7 @@ tmle3_psi <- tmle_fit$summary$tmle_est
 tmle3_se <- tmle_fit$summary$se
 tmle3_epsilon <- updater$epsilons[[1]]$Y
 
-submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, -1)
+submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, "full")
 #################################################
 # compare with the tmle package
 library(tmle)

--- a/tests/testthat/test-cv_tmle.R
+++ b/tests/testthat/test-cv_tmle.R
@@ -63,7 +63,7 @@ tmle3_psi <- tmle_fit$summary$tmle_est
 tmle3_se <- tmle_fit$summary$se
 tmle3_epsilon <- updater$epsilons[[1]]$Y
 
-submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, 0)
+submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, "validation")
 #################################################
 # compare with the tmle package
 library(tmle)
@@ -75,16 +75,16 @@ library(tmle)
 cf_task <- tsm$cf_likelihood$cf_tasks[[1]]
 
 # get Q
-EY1 <- initial_likelihood$get_likelihoods(cf_task, "Y", 0)
+EY1 <- initial_likelihood$get_likelihoods(cf_task, "Y", "validation")
 
-EY1_final <- targeted_likelihood$get_likelihoods(cf_task, "Y", 0)
+EY1_final <- targeted_likelihood$get_likelihoods(cf_task, "Y", "validation")
 EY0 <- rep(0, length(EY1)) # not used
 Q <- cbind(EY0, EY1)
 
-EY <- initial_likelihood$get_likelihoods(tmle_task, "Y", 0)
+EY <- initial_likelihood$get_likelihoods(tmle_task, "Y", "validation")
 
 # get G
-pA1 <- initial_likelihood$get_likelihoods(cf_task, "A", 0)
+pA1 <- initial_likelihood$get_likelihoods(cf_task, "A", "validation")
 pDelta1 <- cbind(pA1, pA1)
 
 tmle_classic_fit <- tmle(


### PR DESCRIPTION
Rename the `cv_fold` argument everywhere it appears in `tmle3` to `fold_number` to match `sl3`
Part of a larger overhaul of cv across the tlverse. 