### PR TITLE
Overhaul Bounded Continuous Outcomes

### DIFF
--- a/R/LF_fit.R
+++ b/R/LF_fit.R
@@ -51,10 +51,9 @@ LF_fit <- R6Class(
       }
 
       outcome_node <- self$name
-      # todo: we don't support delayed tmle_tasks
-      # this relates to the issue of cross_validation for delayed tasks
-      # and not being able to generate delayed calls on-the-fly
-      learner_task <- tmle_task$get_regression_task(outcome_node)
+      
+      # fit scaled task for bounded continuous
+      learner_task <- tmle_task$get_regression_task(outcome_node, bound = TRUE)
       learner_fit <- delayed_learner_train(self$learner, learner_task)
       return(learner_fit)
     },
@@ -66,7 +65,10 @@ LF_fit <- R6Class(
       learner_task <- tmle_task$get_regression_task(self$name)
       learner <- self$learner
       preds <- learner$predict_fold(learner_task, fold_number)
-      return(preds)
+      
+      # unscale preds (to handle bounded continuous)
+      preds_unscaled <- tmle_task$unscale(preds, self$name)
+      return(preds_unscaled)
     },
     get_density = function(tmle_task, fold_number) {
       learner_task <- tmle_task$get_regression_task(self$name)

--- a/R/LF_known.R
+++ b/R/LF_known.R
@@ -50,14 +50,6 @@ LF_known <- R6Class(
       learner_task <- tmle_task$get_regression_task(self$name, bound = FALSE)
       preds <- self$mean_fun(learner_task)
 
-      outcome_type <- learner_task$outcome_type
-
-      bounds <- outcome_type$bounds
-      if (!is.null(bounds)) {
-        scale <- bounds[2] - bounds[1]
-        shift <- bounds[1]
-        preds <- (preds - shift) / scale
-      }
       return(preds)
     },
     get_density = function(tmle_task, fold_number) {

--- a/R/Param_TSM.R
+++ b/R/Param_TSM.R
@@ -89,16 +89,6 @@ Param_TSM <- R6Class(
       # clever_covariates happen here (for all fit params), and this is repeated computation
       EY1 <- unlist(self$cf_likelihood$get_likelihood(cf_task, self$outcome_node, fold_number), use.names = FALSE)
 
-      # todo: integrate unbounding logic into likelihood class, or at least put it in a function
-      variable_type <- tmle_task$npsem[[self$outcome_node]]$variable_type
-      if ((variable_type$type == "continuous") && (!is.na(variable_type$bounds))) {
-        bounds <- variable_type$bounds
-        scale <- bounds[2] - bounds[1]
-        shift <- bounds[1]
-        EYA <- EYA * scale + shift
-        EY1 <- EY1 * scale + shift
-      }
-
       # todo: separate out psi
       # todo: make this a function of f(W)
       psi <- mean(EY1)

--- a/R/Param_mean.R
+++ b/R/Param_mean.R
@@ -49,15 +49,6 @@ Param_mean <- R6Class(
     estimates = function(tmle_task = NULL, fold_number = "full") {
       EY <- self$observed_likelihood$get_likelihood(tmle_task, self$outcome_node, fold_number)
 
-      # todo: integrate unbounding logic into likelihood class, or at least put it in a function
-      variable_type <- tmle_task$npsem[[self$outcome_node]]$variable_type
-      if ((variable_type$type == "continuous") && (!is.na(variable_type$bounds))) {
-        bounds <- variable_type$bounds
-        scale <- bounds[2] - bounds[1]
-        shift <- bounds[1]
-        EY <- EY * scale + shift
-      }
-
       Y <- tmle_task$get_tmle_node(self$outcome_node)
       # todo: separate out psi
       # todo: make this a function of f(W)

--- a/R/Targeted_Likelihood.R
+++ b/R/Targeted_Likelihood.R
@@ -35,10 +35,7 @@ Targeted_Likelihood <- R6Class(
       tasks_at_step <- self$cache$tasks
 
       # first, calculate all updates
-      task_updates <- lapply(tasks_at_step, function(task) {
-        all_submodels <- self$updater$generate_submodel_data(self, task, fold_number)
-        updated_values <- self$updater$apply_submodels(all_submodels, new_epsilons)
-      })
+      task_updates <- lapply(tasks_at_step, self$updater$apply_update, self, fold_number, new_epsilons)
 
       # then, store all updates
       for (task_index in seq_along(tasks_at_step)) {

--- a/R/tmle3_Spec.R
+++ b/R/tmle3_Spec.R
@@ -16,6 +16,7 @@ tmle3_Spec <- R6Class(
     },
     make_tmle_task = function(data, node_list, ...) {
       setDT(data)
+      
       # bound Y if continuous
       Y_node <- node_list$Y
       Y_vals <- unlist(data[, Y_node, with = FALSE])
@@ -24,8 +25,8 @@ tmle3_Spec <- R6Class(
         min_Y <- min(Y_vals)
         max_Y <- max(Y_vals)
         range <- max_Y - min_Y
-        lower <- min_Y # - 0.1 * range
-        upper <- max_Y # + 0.1 * range
+        lower <- min_Y  #- 0.1 * range
+        upper <- max_Y  #+ 0.1 * range
         Y_variable_type <- variable_type(
           type = "continuous",
           bounds = c(lower, upper)

--- a/tests/testthat/test-bounded_continuous.R
+++ b/tests/testthat/test-bounded_continuous.R
@@ -1,0 +1,113 @@
+context("Bounded Continuous - scaling works for continous outcomes")
+
+library(sl3)
+# library(tmle3)
+library(uuid)
+library(assertthat)
+library(data.table)
+library(future)
+# setup data for test
+data(cpp)
+data <- as.data.table(cpp)
+data$parity01 <- as.numeric(data$parity > 0)
+data$parity01_fac <- factor(data$parity01)
+data$haz01 <- as.numeric(data$haz > 0)
+data[is.na(data)] <- 0
+node_list <- list(
+  W = c(
+    "apgar1", "apgar5", "gagebrth", "mage",
+    "meducyrs", "sexn"
+  ),
+  A = "parity01",
+  Y = "haz"
+)
+
+qlib <- make_learner_stack(
+  "Lrnr_mean",
+  "Lrnr_glm_fast"
+)
+
+glib <- make_learner_stack(
+  "Lrnr_mean",
+  "Lrnr_glm_fast"
+)
+
+logit_metalearner <- make_learner(Lrnr_solnp, metalearner_logistic_binomial, loss_loglik_binomial)
+Q_learner <- make_learner(Lrnr_sl, qlib, logit_metalearner)
+g_learner <- make_learner(Lrnr_sl, glib, logit_metalearner)
+learner_list <- list(Y = Q_learner, A = g_learner)
+tmle_spec <- tmle_TSM_all()
+
+# define data
+tmle_task <- tmle_spec$make_tmle_task(data, node_list)
+
+# define likelihood
+initial_likelihood <- tmle_spec$make_initial_likelihood(tmle_task, learner_list)
+
+# define update method (submodel + loss function)
+# disable cvtmle for this test to compare with tmle package
+updater <- tmle3_Update$new(cvtmle = FALSE)
+
+targeted_likelihood <- Targeted_Likelihood$new(initial_likelihood, updater)
+intervention <- define_lf(LF_static, "A", value = 1)
+tsm <- define_param(Param_TSM, targeted_likelihood, intervention)
+updater$tmle_params <- tsm
+
+# debugonce(targeted_likelihood$update)
+tmle_fit <- fit_tmle3(tmle_task, targeted_likelihood, list(tsm), updater)
+
+Q_bar_n <- targeted_likelihood$get_likelihood(tmle_task, "Y")
+
+test_that("likelihood values are not bounded",{
+          expect_true((min(Q_bar_n)<0)||(max(Q_bar_n)>1))
+})
+
+# extract results
+tmle3_psi <- tmle_fit$summary$tmle_est
+tmle3_se <- tmle_fit$summary$se
+tmle3_epsilon <- updater$epsilons[[1]]$Y
+
+submodel_data <- updater$generate_submodel_data(initial_likelihood, tmle_task, "full")
+
+#################################################
+# compare with the tmle package
+library(tmle)
+
+# construct likelihood estimates
+
+# task for A=1
+# cf_task <- tmle_task$generate_counterfactual_task(UUIDgenerate(), data.table(A = 1))
+cf_task <- tsm$cf_likelihood$cf_tasks[[1]]
+
+# get Q
+EY1 <- initial_likelihood$get_likelihoods(cf_task, "Y")
+EY1_final <- targeted_likelihood$get_likelihoods(cf_task, "Y")
+EY0 <- rep(0, length(EY1)) # not used
+Q <- cbind(EY0, EY1)
+
+# get G
+pA1 <- initial_likelihood$get_likelihoods(cf_task, "A")
+pDelta1 <- cbind(pA1, pA1)
+tmle_classic_fit <- tmle(
+  Y = tmle_task$get_tmle_node("Y"),
+  Qbounds = tmle_task$get_node_bounds("Y"),
+  A = NULL,
+  W = tmle_task$get_tmle_node("W"),
+  Delta = tmle_task$get_tmle_node("A"),
+  Q = Q,
+  pDelta1 = pDelta1
+)
+
+cf_task <- tsm$cf_likelihood$cf_tasks[[1]]
+# debugonce(tsm$cf_likelihood$enumerate_cf_tasks)
+
+# extract estimates
+classic_psi <- tmle_classic_fit$estimates$EY1$psi
+classic_se <- sqrt(tmle_classic_fit$estimates$EY1$var.psi)
+classic_epsilon <- tmle_classic_fit$epsilon[["H1W"]]
+classic_Qstar <- tmle_classic_fit$Qstar[, 2]
+
+test_that("Qstar matches result from classic package", expect_equivalent(EY1_final, classic_Qstar))
+test_that("psi matches result from classic package", expect_equal(tmle3_psi, classic_psi))
+test_that("se matches result from classic package", expect_equal(tmle3_se, classic_se))
+test_that("epsilon matches resullt from classic package", expect_equivalent(tmle3_epsilon, classic_epsilon))


### PR DESCRIPTION
Bounded Continuous outcome support is more cohesive now. Likelihood values and task values are both on the true outcome scale. Outcomes are scaled in two places:
* When fitting a regression for a bounded continuous outcome via `lf_fit`
* In the update procedure

This means that `Param`s, amongst other objects, don't need to worry about bounding.