### PR TITLE
enable optional caching, add test

### DIFF
--- a/R/LF_base.R
+++ b/R/LF_base.R
@@ -23,11 +23,12 @@ LF_base <- R6Class(
   portable = TRUE,
   class = TRUE,
   public = list(
-    initialize = function(name, bound = NULL, ..., type = "density") {
+    initialize = function(name, bound = NULL, ..., type = "density", cache=TRUE) {
       private$.name <- name
       private$.type <- type
       private$.bound <- bound
       private$.uuid <- UUIDgenerate(use.time = TRUE)
+      private$.cache <- cache
     },
     delayed_train = function(tmle_task) {
       return(list())
@@ -88,6 +89,9 @@ LF_base <- R6Class(
     },
     bound = function() {
       return(private$.bound)
+    },
+    cache = function(){
+      return(private$.cache)
     }
   ),
   private = list(
@@ -96,7 +100,8 @@ LF_base <- R6Class(
     .memoized_values = list(),
     .type = NULL,
     .uuid = NULL,
-    .bound = NULL
+    .bound = NULL,
+    .cache = TRUE
   )
 )
 

--- a/R/Likelihood_cache.R
+++ b/R/Likelihood_cache.R
@@ -28,6 +28,11 @@ Likelihood_cache <- R6Class(
     },
     set_values = function(likelihood_factor, tmle_task, update_step = 0, fold_number, values) {
       self$cache_task(tmle_task)
+      
+      # respect likelihood factors that don't want to cache
+      if(!likelihood_factor$cache){
+        return(0)
+      }
       key <- self$key(likelihood_factor, tmle_task, fold_number)
       assign(key, values, self$cache)
 

--- a/tests/testthat/test-Likelihood_cache.R
+++ b/tests/testthat/test-Likelihood_cache.R
@@ -1,0 +1,61 @@
+context("Basic interventions: TSM for single static intervention.")
+
+library(sl3)
+# library(tmle3)
+library(uuid)
+library(assertthat)
+library(data.table)
+library(future)
+# setup data for test
+data(cpp)
+data <- as.data.table(cpp)
+data$parity01 <- as.numeric(data$parity > 0)
+data$parity01_fac <- factor(data$parity01)
+data$haz01 <- as.numeric(data$haz > 0)
+data[is.na(data)] <- 0
+node_list <- list(
+  W = c(
+    "apgar1", "apgar5", "gagebrth", "mage",
+    "meducyrs", "sexn"
+  ),
+  A = "parity01",
+  Y = "haz01"
+)
+
+qlib <- make_learner_stack(
+  "Lrnr_mean",
+  "Lrnr_glm_fast"
+)
+
+glib <- make_learner_stack(
+  "Lrnr_mean",
+  "Lrnr_glm_fast"
+)
+
+logit_metalearner <- make_learner(Lrnr_solnp, metalearner_logistic_binomial, loss_loglik_binomial)
+Q_learner <- make_learner(Lrnr_sl, qlib, logit_metalearner)
+g_learner <- make_learner(Lrnr_sl, glib, logit_metalearner)
+learner_list <- list(Y = Q_learner, A = g_learner)
+tmle_spec <- tmle_TSM_all()
+
+# define data
+tmle_task <- tmle_spec$make_tmle_task(data, node_list)
+
+W_factor <- define_lf(LF_emp, "W")
+A_factor <- define_lf(LF_fit, "A", learner = learner_list[["A"]], cache=FALSE)
+Y_factor <- define_lf(LF_fit, "Y", learner = learner_list[["Y"]], type = "mean")
+
+# construct and train likelihood
+factor_list <- list(W_factor, A_factor, Y_factor)
+
+likelihood_def <- Likelihood$new(factor_list)
+likelihood <- likelihood_def$train(tmle_task)
+
+# get likelihood values to populate cache
+likelihood_values <- likelihood$get_likelihoods(tmle_task)
+
+A_values <- likelihood$cache$get_values(A_factor, tmle_task, "full")
+Y_values <- likelihood$cache$get_values(Y_factor, tmle_task, "full")
+
+test_that("caching works",expect_length(Y_values,tmle_task$nrow))
+test_that("disabling caching works",expect_null(A_values))


### PR DESCRIPTION
When likelihood factors depend on other likelihood factors that update, caching prevents the dependent factor from also being updated. This adds an option to disable caching on such likelihood factors.