### PR TITLE
Updater modifications

### DIFF
--- a/man/tmle3_Update.Rd
+++ b/man/tmle3_Update.Rd
@@ -34,8 +34,13 @@ loss function and submodel are hard-coded (need to accept arguments for these)
        \code{constrain_step} is \code{TRUE}.
     }
     \item{\code{convergence_type}}{The convergence criterion to use: (1)
-       \code{"se_logn"} corresponds to sqrt(Var(D)/n)/logn (the default)
-       while (2) \code{"n_samp"} corresponds to 1/n.
+       \code{"scaled_var"} corresponds to sqrt(Var(D)/n)/logn (the default)
+       while (2) \code{"sample_size"} corresponds to 1/n.
+    }
+    \item{\code{fluctuation_type}}{Whether to include the auxiliary covariate
+       for the fluctuation model as a covariate or to treat it as a weight.
+       Note that the option \code{"weighted"} is incompatible with a
+       multi-epsilon submodel (\code{one_dimensional = FALSE}).
     }
     \item{\code{verbose}}{If \code{TRUE}, diagnostic output is generated
        about the updating procedure.

--- a/tests/testthat/test-ATE.R
+++ b/tests/testthat/test-ATE.R
@@ -1,4 +1,4 @@
-context("Direct ATE for single node interventions.")
+context("Direct ATE for single node interventions")
 
 library(sl3)
 library(tmle3)

--- a/tests/testthat/test-ATE_categorical.R
+++ b/tests/testthat/test-ATE_categorical.R
@@ -1,4 +1,4 @@
-context("Direct ATE for single node interventions.")
+context("Direct ATE for single node interventions")
 
 library(sl3)
 library(tmle3)

--- a/tests/testthat/test-ATT.R
+++ b/tests/testthat/test-ATT.R
@@ -1,4 +1,4 @@
-context("Basic interventions: TSM and ATE for single node interventions.")
+context("Basic interventions: TSM and ATE for single node interventions")
 
 library(sl3)
 library(tmle3)

--- a/tests/testthat/test-Likelihood_cache.R
+++ b/tests/testthat/test-Likelihood_cache.R
@@ -1,4 +1,4 @@
-context("Basic interventions: TSM for single static intervention.")
+context("Caching of Likelihood objects")
 
 library(sl3)
 # library(tmle3)

--- a/tests/testthat/test-PAR.R
+++ b/tests/testthat/test-PAR.R
@@ -1,4 +1,4 @@
-context("Population Attributable Risk and Fraction")
+context("Population attributable risk and fraction")
 
 library(sl3)
 library(uuid)

--- a/tests/testthat/test-RR.R
+++ b/tests/testthat/test-RR.R
@@ -1,4 +1,4 @@
-context("Risk Ratios")
+context("Risk ratios")
 
 library(sl3)
 library(uuid)

--- a/tests/testthat/test-basic_intevention.R
+++ b/tests/testthat/test-basic_intevention.R
@@ -1,4 +1,4 @@
-context("Basic interventions: TSM for single static intervention.")
+context("Basic interventions: TSM for single static intervention")
 
 library(sl3)
 # library(tmle3)

--- a/tests/testthat/test-bounded_continuous.R
+++ b/tests/testthat/test-bounded_continuous.R
@@ -1,4 +1,4 @@
-context("Bounded Continuous - scaling works for continous outcomes")
+context("Bounded continuous: scaling works for continous outcomes")
 
 library(sl3)
 # library(tmle3)

--- a/tests/testthat/test-cluster_variance.R
+++ b/tests/testthat/test-cluster_variance.R
@@ -1,4 +1,4 @@
-context("Repeated measures: Check variance is computed from subject-level ICs")
+context("Repeated measures: check variance is computed from subject-level ICs")
 
 library(sl3)
 library(uuid)

--- a/tests/testthat/test-cv_likelihood.R
+++ b/tests/testthat/test-cv_likelihood.R
@@ -1,4 +1,4 @@
-context("CV-Likelihood: Fold-specific Likelihood estimates")
+context("CV-Likelihood: fold-specific Likelihood estimates")
 
 set.seed(1234)
 library(sl3)

--- a/tests/testthat/test-cv_tmle.R
+++ b/tests/testthat/test-cv_tmle.R
@@ -1,4 +1,4 @@
-context("CV-TMLE: TSM for single static intervention.")
+context("CV-TMLE: TSM for single static intervention")
 set.seed(1234)
 library(sl3)
 # library(tmle3)

--- a/tests/testthat/test-impute_missing.R
+++ b/tests/testthat/test-impute_missing.R
@@ -1,4 +1,4 @@
-context("Missingness Processing")
+context("Missingness processing")
 library(sl3)
 data(cpp)
 data <- as.data.table(cpp)

--- a/tests/testthat/test-lf_derived.R
+++ b/tests/testthat/test-lf_derived.R
@@ -1,4 +1,4 @@
-context("LF_derived: Derived Likelihood factors")
+context("Derived Likelihood factors")
 
 context("TML estimator for incremental propensity score interventions")
 

--- a/tests/testthat/test-lf_derived.R
+++ b/tests/testthat/test-lf_derived.R
@@ -1,7 +1,5 @@
 context("Derived Likelihood factors")
 
-context("TML estimator for incremental propensity score interventions")
-
 library(data.table)
 library(stringr)
 library(future)
@@ -103,7 +101,6 @@ make_e_task <- function(tmle_task, likelihood) {
   )
   return(e_task)
 }
-
 
 lf_e <- define_lf(LF_derived, "e", glm_fast, likelihood_targeted, make_e_task)
 likelihood_targeted$add_factors(lf_e)

--- a/tests/testthat/test-lf_known.R
+++ b/tests/testthat/test-lf_known.R
@@ -1,4 +1,4 @@
-context("test-lf_known - Pass in known likelihoods as input")
+context("Pass in known likelihood factors as input")
 
 library(data.table)
 library(sl3)

--- a/tests/testthat/test-unadjusted.R
+++ b/tests/testthat/test-unadjusted.R
@@ -1,4 +1,4 @@
-context("Basic interventions: TSM for single static intervention.")
+context("Basic interventions: TSM for single static intervention")
 
 library(sl3)
 # library(tmle3)

--- a/tests/testthat/test-universal_submodel.R
+++ b/tests/testthat/test-universal_submodel.R
@@ -109,7 +109,7 @@ classic_Qstar <- tmle_classic_fit$Qstar[, 2]
 
 # test_that("Qstar matches result from classic package", expect_equivalent(EY1_final, classic_Qstar))
 test_that("psi matches result from classic package", {
-  expect_equal(tmle3_psi, classic_psi, tol = 1e-3)
+  expect_equal(tmle3_psi, classic_psi, tol = 2e-3)
 })
 test_that("se matches result from classic package", {
   expect_equal(tmle3_se, classic_se, tol = 1e-3)

--- a/tests/testthat/test-universal_submodel.R
+++ b/tests/testthat/test-universal_submodel.R
@@ -1,4 +1,4 @@
-context("universal submodel")
+context("Universal submodel")
 
 library(sl3)
 library(tmle3)

--- a/tests/testthat/test-vim.R
+++ b/tests/testthat/test-vim.R
@@ -1,4 +1,4 @@
-context("Variable Importance Measure Framework")
+context("Variable importance measure framework")
 
 library(sl3)
 library(uuid)


### PR DESCRIPTION
For the Updater class, this PR adds

* the option `start = 0` (in the `glm` call) for all auxiliary covariates in order to ensure that update steps do not generally get out of hand (this has been successfully used in the drtmle, survtmle, txshift packages and can generally pose a problem with more troublesome TML estimators).
* the new argument `fluctuation_type`, which allows the option for using the auxiliary covariates values as weights instead of regressors. the default remains to treat them as regressors and the weighted option collapses to the standard in the event of multi-epsilon submodels.

Some cleanup of unit testing code is also performed.