### PR TITLE
update tests to reflect change in tmle::tmle defaults

### DIFF
--- a/tests/testthat/test-basic_intevention.R
+++ b/tests/testthat/test-basic_intevention.R
@@ -94,7 +94,10 @@ tmle_classic_fit <- tmle(
   W = tmle_task$get_tmle_node("W"),
   Delta = tmle_task$get_tmle_node("A"),
   Q = Q,
-  pDelta1 = pDelta1
+  pDelta1 = pDelta1,
+  family="binomial",
+  alpha=0.995,
+  target.gwt = FALSE
 )
 
 cf_task <- tsm$cf_likelihood$cf_tasks[[1]]

--- a/tests/testthat/test-bounded_continuous.R
+++ b/tests/testthat/test-bounded_continuous.R
@@ -101,7 +101,9 @@ tmle_classic_fit <- tmle(
   W = tmle_task$get_tmle_node("W"),
   Delta = tmle_task$get_tmle_node("A"),
   Q = Q,
-  pDelta1 = pDelta1
+  pDelta1 = pDelta1,
+  alpha=0.995,
+  target.gwt = FALSE
 )
 
 cf_task <- tsm$cf_likelihood$cf_tasks[[1]]

--- a/tests/testthat/test-cv_tmle.R
+++ b/tests/testthat/test-cv_tmle.R
@@ -99,7 +99,10 @@ tmle_classic_fit <- tmle(
   W = tmle_task$get_tmle_node("W"),
   Delta = tmle_task$get_tmle_node("A"),
   Q = Q,
-  pDelta1 = pDelta1
+  pDelta1 = pDelta1,
+  family="binomial",
+  alpha=0.995,
+  target.gwt = FALSE
 )
 
 

--- a/tests/testthat/test-unadjusted.R
+++ b/tests/testthat/test-unadjusted.R
@@ -73,7 +73,11 @@ tmle_classic_fit <- tmle(
   W = W,
   Delta = tmle_task$get_tmle_node("A"),
   Q = Q,
-  pDelta1 = pDelta1
+  pDelta1 = pDelta1,
+  family="binomial",
+  alpha=0.995,
+  target.gwt = FALSE,
+  prescreenW.g = FALSE
 )
 
 # extract estimates


### PR DESCRIPTION
Changes to tmle defaults broke tests that expected matching estimates between the two packages.  This PR updates those tests by changing the options to tmle.