### PR TITLE
likelihood warnings added to validate_task

### DIFF
--- a/R/Likelihood.R
+++ b/R/Likelihood.R
@@ -59,6 +59,11 @@ Likelihood <- R6Class(
       if (!all(factor_names %in% task_nodes)) {
         stop("factor_list and task$npsem must have matching names")
       }
+
+      factor_types <- lapply(factor_list, function(x) x.type())
+      if (("density" %in% factor_types) & ("continuous" %in% factor_types)) {
+        warning("bounded continuous is being used with density type outcome")
+      }
     },
     get_likelihood = function(tmle_task, node, fold_number = "full") {
       likelihood_factor <- self$factor_list[[node]]


### PR DESCRIPTION
Hi Jeremy,

As per #42 , I've added some code to the `validate_task` function in `Likelihood.R` that will do the following:
1. Find all of the variable types in a factor_list
2. check for whether there exists a "continuous" variable for a "density" outcome.
3. If both are true, then a `warning()` is thrown.

Please let me know if you'd like me to write tests, as well as update the [reference website](https://tlverse.org/tmle3/reference/Likelihood.html#methods) with the added warning.