### PR TITLE
Minor bug fix

### DIFF
--- a/R/tmle3_Task.R
+++ b/R/tmle3_Task.R
@@ -349,6 +349,7 @@ tmle3_Task <- R6Class(
     },
     data = function() {
       all_variables <- unlist(lapply(self$npsem, `[[`, "variables"))
+      all_variables <- unique(all_variables)
       self$get_data(columns = all_variables)
     }
   ),


### PR DESCRIPTION
Bug in self$data function of tmle3_Task
If all_variables contains duplicate variables then data.table throws an error. This can occur if someone has likelihood nodes that share variables.