### PR TITLE
use requireNamespace for optional test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Suggests:
     Rsolnp,
     nnls,
     tmle,
+    tmle3shift,
     future,
     future.apply,
     xgboost

--- a/tests/testthat/test-lf_known.R
+++ b/tests/testthat/test-lf_known.R
@@ -64,8 +64,8 @@ learner_list <- list(
 )
 
 # pass defined likelihood into existing spec
-if (require("tmle3shift")) {
-  tmle_spec <- tmle_shift(
+if (requireNamespace("tmle3shift", quietly = TRUE)) {
+  tmle_spec <- tmle3shift::tmle_shift(
     shift_val = 0.5,
     likelihood_override = likelihood_def
   )


### PR DESCRIPTION
require() throws a warning if not installed, this will be an error for options(warn = 2).

Also add the package to Suggests to indicate its usage in the tests.